### PR TITLE
upd: postfix::prepare_hard_config_management  - notify /etc/postfix/{mai...

### DIFF
--- a/manifests/prepare_hard_config_management.pp
+++ b/manifests/prepare_hard_config_management.pp
@@ -14,6 +14,7 @@ class postfix::prepare_hard_config_management {
     warn    => true,
     replace => true,
     backup  => false,
+    notify  => Service['postfix'],
   }
 
   concat::fragment { 'postfix master.cf header':


### PR DESCRIPTION
Hi Axel ;) !

The fix to notify the postfix service when main.cf or master get changed